### PR TITLE
allow url tokens to be specified separately from page

### DIFF
--- a/views/partials/analytics.html
+++ b/views/partials/analytics.html
@@ -7,7 +7,7 @@
     ga('set', 'anonymizeIp', true);
     ga('create', '{{ga-id}}', 'auto');
     {{$ga-page-view}}
-    ga('send', 'pageview'{{#ga-page}}, '{{ga-page}}'{{/ga-page}});
+    ga('send', 'pageview'{{#ga-page}}, '{{ga-page}}{{ga-tokens}}'{{/ga-page}});
     {{/ga-page-view}}
     {{#ga-page}}
     {{#errorlist.length}}


### PR DESCRIPTION
ga analytics errors are specified by convention as
ga-page: `/page/name|token1|token2`

separate off the tokens from the page so the  raw page name can be used for events
ga-page: `/page/name`
ga-tokens: `|token1|token2`

this is backwards compatible as the tokens could still be specified in the ga-page
