### PR TITLE
Remove govuk template asset hosting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # hmpo-templates
 
-Common page layouts and partials. Inherits from [hmpo-govuk-template](https://github.com/UKHomeOffice/govuk-template-compiler).
+Common page layouts and partials.
 
 ## Installation
 
@@ -10,9 +10,11 @@ npm install [--save] hmpo-templates
 
 ## Setup
 
-Install [hogan-express-strict](https://github.com/lennym/hogan-express) and [express-partial-templates](https://github.com/UKHomeOffice/express-partial-templates) as part of your project.
+Install [hmpo-govuk-template](https://github.com/UKHomeOffice/govuk-template-compiler), [hogan-express-strict](https://github.com/lennym/hogan-express) and [express-partial-templates](https://github.com/UKHomeOffice/express-partial-templates) as part of your project.
 ```
 var app = require('express')();
+
+require('hmpo-govuk-template').setup(app);
 
 app.set('view engine', 'html');
 app.use(require('hmpo-templates'));

--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 var app = require('express')(),
     path = require('path');
 
-require('hmpo-govuk-template').setup(app, { path: '/public/govuk-assets' });
-
 app.set('view engine', 'html');
 app.set('views', path.resolve(__dirname, './views'));
 app.use(require('express-partial-templates')(app, { prefix: 'hmpo' }));

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "homepage": "https://github.com/UKHomeOffice/passports-templates#readme",
   "dependencies": {
     "express": "^4.13.4",
-    "express-partial-templates": "^0.2.0",
-    "hmpo-govuk-template": "^0.1.0"
+    "express-partial-templates": "^0.2.0"
   }
 }


### PR DESCRIPTION
Remove setup of hosting govuk assets every time passport templates is used.

The app using this module can decide if it wants to use host the assets every time or only add the template to local partials.